### PR TITLE
install build deps from packages

### DIFF
--- a/src/freebsd-server.html
+++ b/src/freebsd-server.html
@@ -462,6 +462,8 @@
                                             <code>
                                                 # Reinstall FFMpeg from ports with lame option enabled<br>
                                                 cd /usr/ports/multimedia/ffmpeg<br>
+                                                # Install ffmpeg build dependencies<br>
+                                                pkg install `make build-depends-list | tr '\n' ' ' | sed 's/\/usr\/ports\///g' | sed 's/audio\/lame //g'`<br>
                                                 make config<br>
                                                 # enable the lame option<br>
                                                 # enable the ass subtitles option<br>


### PR DESCRIPTION
These instructions will help people get up and running on freebsd quite a bit faster. Instead of building all of the build dependencies for ffmpeg from source, they can be installed as packages so that the only thing that needs to be compiled is lame and ffmpeg.